### PR TITLE
Fix link to Google fonts vertical metrics doc

### DIFF
--- a/opentype.md
+++ b/opentype.md
@@ -239,7 +239,7 @@ So how should actually we set these values? Unfortunately, there is not a real c
 
 * Bit 7 of `fsSelection` should be turned on.
 
-If you don't like this strategy, there are plenty of others to choose from. The [Glyphs web site](https://www.glyphsapp.com/tutorials/vertical-metrics) describes the strategies used by Adobe, Microsoft and web fonts; [Google fonts](https://github.com/googlefonts/gf-docs/blob/master/VerticalMetricsRecommendations.md) has another. Karsten Lucke has a [guide](https://www.kltf.de/downloads/FontMetrics-kltf.pdf) which goes into all of this in excruciating detail but finally lands on the strategy mentioned above.
+If you don't like this strategy, there are plenty of others to choose from. The [Glyphs web site](https://www.glyphsapp.com/tutorials/vertical-metrics) describes the strategies used by Adobe, Microsoft and web fonts; [Google fonts](https://github.com/googlefonts/gf-docs/tree/main/VerticalMetrics) has another. Karsten Lucke has a [guide](https://www.kltf.de/downloads/FontMetrics-kltf.pdf) which goes into all of this in excruciating detail but finally lands on the strategy mentioned above.
 
 Yes, this is a complete hot mess. Sorry.
 


### PR DESCRIPTION
The doc at the old location was deleted in
https://github.com/googlefonts/gf-docs/commit/00636cff8cf1d249a5bc99d128f5b7d748a19d69

The new doc was added in
https://github.com/googlefonts/gf-docs/commit/d0c6a99bd3377994adc6ed1b3d3f1ced8eee92a8
and then moved around to the current location in
https://github.com/googlefonts/gf-docs/commit/eb672de11d715817c44d4299a29741954f19c682#diff-f5321af11bbd394f819aee86f5600d1d1bfdf5d04f6a476b3714c387d8d98355